### PR TITLE
Add Gradle task name to run configuration names

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ pluginVersion = 1.0.9
 platformType = IC
 platformVersion = 2024.2
 
-platformPlugins = java
+platformPlugins = java, com.intellij.gradle
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 7.5.1

--- a/src/main/kotlin/com/github/sorinflorea/runconfigextras/ConfigNaming.kt
+++ b/src/main/kotlin/com/github/sorinflorea/runconfigextras/ConfigNaming.kt
@@ -1,0 +1,67 @@
+package com.github.sorinflorea.runconfigextras
+
+import com.intellij.execution.RunManagerEx
+import com.intellij.execution.RunnerAndConfigurationSettings
+import com.intellij.openapi.externalSystem.service.execution.ExternalSystemRunConfiguration
+
+object ConfigNaming {
+
+    private val NUMERIC_SUFFIX = Regex("\\s+\\(\\d+\\)$")
+
+    /**
+     * Extracts the Gradle task name from an ExternalSystemRunConfiguration.
+     * Returns the short task name (after the last ':'), or null if not applicable.
+     */
+    fun extractTaskName(settings: RunnerAndConfigurationSettings): String? {
+        val config = settings.configuration
+        if (config !is ExternalSystemRunConfiguration) return null
+        return config.settings.taskNames
+            .firstOrNull { it.startsWith(":") }
+            ?.substringAfterLast(':')
+    }
+
+    /**
+     * Computes the desired name for a configuration including its Gradle task name.
+     * Returns e.g. "MyTest (testJar)", or null if the config is not applicable or
+     * the name already has the correct task suffix.
+     */
+    fun computeTargetBaseName(settings: RunnerAndConfigurationSettings): String? {
+        val taskName = extractTaskName(settings) ?: return null
+
+        val currentName = settings.name
+        if (currentName.endsWith("($taskName)")) return null
+
+        val baseName = NUMERIC_SUFFIX.find(currentName)?.let {
+            currentName.substring(0, it.range.first)
+        } ?: currentName
+
+        return "$baseName ($taskName)"
+    }
+
+    /**
+     * Prepares RunManager for a new config with [targetName] by removing conflicts.
+     *
+     * - Same test + same task (exact name match): always removes the existing temporary config.
+     * - Same test + different task: only removes if [replaceDifferentTask] is true.
+     * - Saved (non-temporary) configs are never removed.
+     */
+    fun resolveTargetName(
+        targetName: String,
+        runManager: RunManagerEx,
+        replaceDifferentTask: Boolean
+    ) {
+        // Same test + same task: always replace temporary config
+        runManager.allSettings
+            .find { it.name == targetName && it.isTemporary }
+            ?.let { runManager.removeConfiguration(it) }
+
+        // Same test + different task: replace only if setting is enabled
+        if (replaceDifferentTask) {
+            val baseName = targetName.substringBeforeLast(" (")
+            val baseNamePattern = Regex("^${Regex.escape(baseName)} \\(.+\\)$")
+            runManager.allSettings
+                .filter { it.isTemporary && it.name != targetName && baseNamePattern.matches(it.name) }
+                .forEach { runManager.removeConfiguration(it) }
+        }
+    }
+}

--- a/src/main/kotlin/com/github/sorinflorea/runconfigextras/actions/BaseRunConfigAction.kt
+++ b/src/main/kotlin/com/github/sorinflorea/runconfigextras/actions/BaseRunConfigAction.kt
@@ -1,14 +1,17 @@
 package com.github.sorinflorea.runconfigextras.actions
 
+import com.intellij.execution.ProgramRunnerUtil
+import com.intellij.execution.RunManagerEx
 import com.intellij.execution.RunnerAndConfigurationSettings
 import com.intellij.execution.actions.ConfigurationContext
 import com.intellij.execution.actions.RunContextAction
 import com.intellij.openapi.actionSystem.ActionUpdateThreadAware
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.externalSystem.service.execution.ExternalSystemRunConfiguration
 import com.intellij.openapi.util.IconLoader
-import kotlin.reflect.full.memberFunctions
-import kotlin.reflect.jvm.isAccessible
+import com.github.sorinflorea.runconfigextras.ConfigNaming
+import com.github.sorinflorea.runconfigextras.settings.PluginSettings
 
 abstract class BaseRunConfigAction : AnAction(), ActionUpdateThreadAware {
 
@@ -38,10 +41,25 @@ abstract class BaseRunConfigAction : AnAction(), ActionUpdateThreadAware {
         }
 
         override fun perform(configuration: RunnerAndConfigurationSettings, context: ConfigurationContext) {
-            val perform =
-                RunContextAction::class.memberFunctions.find { it.name == "perform" && it.parameters.size == 3 }
-            perform!!.isAccessible = true
-            perform.call(delegate, configuration, context)
+            val project = context.project ?: return
+            val runManager = RunManagerEx.getInstanceEx(project)
+            val replaceDifferentTask = PluginSettings.instance.state.replaceExistingConfig
+
+            val targetName = ConfigNaming.computeTargetBaseName(configuration)
+            if (targetName != null) {
+                ConfigNaming.resolveTargetName(targetName, runManager, replaceDifferentTask)
+
+                val originalConfig = configuration.configuration as ExternalSystemRunConfiguration
+                val clonedConfig = originalConfig.clone()
+                clonedConfig.name = targetName
+                val cloned = runManager.createConfiguration(clonedConfig, originalConfig.factory!!)
+                cloned.isTemporary = true
+                runManager.addConfiguration(cloned)
+                runManager.selectedConfiguration = cloned
+                ProgramRunnerUtil.executeConfiguration(cloned, delegate.executor)
+            } else {
+                super.perform(configuration, context)
+            }
         }
     }
 

--- a/src/main/kotlin/com/github/sorinflorea/runconfigextras/settings/PluginConfigurable.kt
+++ b/src/main/kotlin/com/github/sorinflorea/runconfigextras/settings/PluginConfigurable.kt
@@ -1,0 +1,17 @@
+package com.github.sorinflorea.runconfigextras.settings
+
+import com.intellij.openapi.options.BoundConfigurable
+import com.intellij.ui.dsl.builder.bindSelected
+import com.intellij.ui.dsl.builder.panel
+
+class PluginConfigurable : BoundConfigurable("Run Configuration Extras") {
+
+    override fun createPanel() = panel {
+        group("Gradle Task Name in Configuration Name") {
+            row {
+                checkBox("Replace configuration for the same test when run with a different task")
+                    .bindSelected(PluginSettings.instance.state::replaceExistingConfig)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/github/sorinflorea/runconfigextras/settings/PluginSettings.kt
+++ b/src/main/kotlin/com/github/sorinflorea/runconfigextras/settings/PluginSettings.kt
@@ -1,0 +1,29 @@
+package com.github.sorinflorea.runconfigextras.settings
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+
+@State(name = "RunConfigExtrasSettings", storages = [Storage("RunConfigExtras.xml")])
+@Service(Service.Level.APP)
+class PluginSettings : PersistentStateComponent<PluginSettings.State> {
+
+    class State {
+        var replaceExistingConfig: Boolean = false
+    }
+
+    private var state = State()
+
+    override fun getState(): State = state
+
+    override fun loadState(state: State) {
+        this.state = state
+    }
+
+    companion object {
+        val instance: PluginSettings
+            get() = ApplicationManager.getApplication().getService(PluginSettings::class.java)
+    }
+}

--- a/src/main/resources/META-INF/gradle-support.xml
+++ b/src/main/resources/META-INF/gradle-support.xml
@@ -1,0 +1,3 @@
+<idea-plugin>
+    <!-- Extensions activated when the Gradle plugin is present -->
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,6 +5,8 @@
 
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.java</depends>
+    <depends optional="true" config-file="gradle-support.xml">com.intellij.gradle</depends>
+
     <actions>
         <action id="RunConfigExtras.RunNewConfigurationAction"
                 class="com.github.sorinflorea.runconfigextras.actions.RunNewConfigAction"
@@ -34,5 +36,12 @@
                                   id="RunConfigExtras.RunNewConfigurationActionContributor"
                                   order="last"
                                   implementationClass="com.github.sorinflorea.runconfigextras.actions.RunNewConfigMarkerContributor"/>
+        <applicationService
+                serviceImplementation="com.github.sorinflorea.runconfigextras.settings.PluginSettings"/>
+        <applicationConfigurable
+                parentId="tools"
+                instance="com.github.sorinflorea.runconfigextras.settings.PluginConfigurable"
+                id="RunConfigExtras.Settings"
+                displayName="Run Configuration Extras"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
When using "Run New Configuration" for Gradle tests, configurations are now named with the task (e.g., "MyTest (testJar)") instead of a generic numeric suffix like "MyTest (1)". Configurations are cloned to get their own uniqueID in RunManager, avoiding silent overwrites.

Replacement rules:
- Same test + same task: always replaces the existing temporary config
- Same test + different task: configurable via Settings > Tools
- Saved (non-temporary) configs are never removed

Also adds:
- Optional dependency on com.intellij.gradle
- Settings page under Tools with task replacement toggle
- ConfigNaming utility with integration tests

<img width="1051" height="713" alt="image" src="https://github.com/user-attachments/assets/b8a7ade4-0a6c-43f9-9723-60680117e002" />

---

## Technical Challenges

### RunManager uniqueID-based replacement
IntelliJ's `RunManager.addConfiguration()` identifies configs by `uniqueID`, which is computed as `"${type.displayName}.${name}"`. Two configs with the same name silently replace each other — there's no "add alongside" behavior. This means simply renaming a config and adding it would overwrite any existing config with the same name, including saved ones.

**Solution**: Clone the `ExternalSystemRunConfiguration` via its `clone()` method and wrap it in a new `RunnerAndConfigurationSettings` via `runManager.createConfiguration()`. The clone gets its own uniqueID based on the new name, and the original remains untouched.

### Framework ghost config
The IntelliJ framework adds the original `configuration` object passed to `perform()` through an internal code path (likely `setTemporaryConfiguration`) that we cannot override or intercept. This produces a phantom `"TestName (1)"` config alongside our correctly named clone. Attempts to remove it via `RunManagerListener` (matching by uniqueID or instance identity) and `invokeLater` cleanup were unsuccessful — the listener never fires for this config.

**Accepted limitation**: The phantom `(1)` config persists. The correctly named config (e.g., `TestName (testJar)`) is properly added, selected in the dropdown, and executed.

### Config name not available at `perform()` time
The `(N)` suffix from `RunManager.suggestUniqueName()` is only used in the settings dialog — configs arrive at `perform()` with their base name (e.g., `"MyTest"`, not `"MyTest (1)"`). The task names in `ExternalSystemTaskExecutionSettings` are populated by the configuration producer before `perform()` is called, so they are available for our rename logic.