### PR TITLE
Test rules for Gradle run configurations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
 fun properties(key: String) = project.findProperty(key).toString()
 
@@ -36,6 +37,7 @@ dependencies {
         bundledPlugin("com.intellij.java")
         bundledPlugin("com.intellij.gradle")
         bundledPlugin("org.jetbrains.plugins.gradle")
+        testFramework(TestFrameworkType.JUnit5)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
         bundledPlugin("org.jetbrains.plugins.gradle")
         testFramework(TestFrameworkType.JUnit5)
     }
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.0")
 }
 
 // Set the JVM language level used to build project. Use Java 11 for 2020.3+, and Java 17 for 2022.2+.

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ pluginVersion = 1.0.9
 platformType = IC
 platformVersion = 2024.2
 
-platformPlugins = java
+platformPlugins = java, com.intellij.gradle
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 7.5.1

--- a/src/main/kotlin/com/github/sorinflorea/runconfigextras/ConfigNaming.kt
+++ b/src/main/kotlin/com/github/sorinflorea/runconfigextras/ConfigNaming.kt
@@ -1,0 +1,67 @@
+package com.github.sorinflorea.runconfigextras
+
+import com.intellij.execution.RunManagerEx
+import com.intellij.execution.RunnerAndConfigurationSettings
+import com.intellij.openapi.externalSystem.service.execution.ExternalSystemRunConfiguration
+
+object ConfigNaming {
+
+    private val NUMERIC_SUFFIX = Regex("\\s+\\(\\d+\\)$")
+
+    /**
+     * Extracts the Gradle task name from an ExternalSystemRunConfiguration.
+     * Returns the short task name (after the last ':'), or null if not applicable.
+     */
+    fun extractTaskName(settings: RunnerAndConfigurationSettings): String? {
+        val config = settings.configuration
+        if (config !is ExternalSystemRunConfiguration) return null
+        return config.settings.taskNames
+            .firstOrNull { it.startsWith(":") }
+            ?.substringAfterLast(':')
+    }
+
+    /**
+     * Computes the desired name for a configuration including its Gradle task name.
+     * Returns e.g. "MyTest (testJar)", or null if the config is not applicable or
+     * the name already has the correct task suffix.
+     */
+    fun computeTargetBaseName(settings: RunnerAndConfigurationSettings): String? {
+        val taskName = extractTaskName(settings) ?: return null
+
+        val currentName = settings.name
+        if (currentName.endsWith("($taskName)")) return null
+
+        val baseName = NUMERIC_SUFFIX.find(currentName)?.let {
+            currentName.substring(0, it.range.first)
+        } ?: currentName
+
+        return "$baseName ($taskName)"
+    }
+
+    /**
+     * Prepares RunManager for a new config with [targetName] by removing conflicts.
+     *
+     * - Same test + same task (exact name match): always removes the existing temporary config.
+     * - Same test + different task: only removes if [replaceDifferentTask] is true.
+     * - Saved (non-temporary) configs are never removed.
+     */
+    fun resolveTargetName(
+        targetName: String,
+        runManager: RunManagerEx,
+        replaceDifferentTask: Boolean
+    ) {
+        // Same test + same task: always replace temporary config
+        runManager.allSettings
+            .find { it.name == targetName && it.isTemporary }
+            ?.let { runManager.removeConfiguration(it) }
+
+        // Same test + different task: replace only if setting is enabled
+        if (replaceDifferentTask) {
+            val baseName = targetName.substringBeforeLast(" (")
+            val baseNamePattern = Regex("^${Regex.escape(baseName)} \\(.+\\)$")
+            runManager.allSettings
+                .filter { it.isTemporary && it.name != targetName && baseNamePattern.matches(it.name) }
+                .forEach { runManager.removeConfiguration(it) }
+        }
+    }
+}

--- a/src/main/kotlin/com/github/sorinflorea/runconfigextras/actions/BaseRunConfigAction.kt
+++ b/src/main/kotlin/com/github/sorinflorea/runconfigextras/actions/BaseRunConfigAction.kt
@@ -1,14 +1,17 @@
 package com.github.sorinflorea.runconfigextras.actions
 
+import com.intellij.execution.ProgramRunnerUtil
+import com.intellij.execution.RunManagerEx
 import com.intellij.execution.RunnerAndConfigurationSettings
 import com.intellij.execution.actions.ConfigurationContext
 import com.intellij.execution.actions.RunContextAction
 import com.intellij.openapi.actionSystem.ActionUpdateThreadAware
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.externalSystem.service.execution.ExternalSystemRunConfiguration
 import com.intellij.openapi.util.IconLoader
-import kotlin.reflect.full.memberFunctions
-import kotlin.reflect.jvm.isAccessible
+import com.github.sorinflorea.runconfigextras.ConfigNaming
+import com.github.sorinflorea.runconfigextras.settings.PluginSettings
 
 abstract class BaseRunConfigAction : AnAction(), ActionUpdateThreadAware {
 
@@ -38,10 +41,25 @@ abstract class BaseRunConfigAction : AnAction(), ActionUpdateThreadAware {
         }
 
         override fun perform(configuration: RunnerAndConfigurationSettings, context: ConfigurationContext) {
-            val perform =
-                RunContextAction::class.memberFunctions.find { it.name == "perform" && it.parameters.size == 3 }
-            perform!!.isAccessible = true
-            perform.call(delegate, configuration, context)
+            val project = context.project ?: return
+            val runManager = RunManagerEx.getInstanceEx(project)
+            val replaceDifferentTask = PluginSettings.instance.state.replaceExistingConfig
+
+            val targetName = ConfigNaming.computeTargetBaseName(configuration)
+            if (targetName != null) {
+                ConfigNaming.resolveTargetName(targetName, runManager, replaceDifferentTask)
+
+                val originalConfig = configuration.configuration as ExternalSystemRunConfiguration
+                val clonedConfig = originalConfig.clone()
+                clonedConfig.name = targetName
+                val cloned = runManager.createConfiguration(clonedConfig, originalConfig.factory!!)
+                cloned.isTemporary = true
+                runManager.addConfiguration(cloned)
+                runManager.selectedConfiguration = cloned
+                ProgramRunnerUtil.executeConfiguration(cloned, delegate.executor)
+            } else {
+                super.perform(configuration, context)
+            }
         }
     }
 

--- a/src/main/kotlin/com/github/sorinflorea/runconfigextras/rules/TestRule.kt
+++ b/src/main/kotlin/com/github/sorinflorea/runconfigextras/rules/TestRule.kt
@@ -1,0 +1,9 @@
+package com.github.sorinflorea.runconfigextras.rules
+
+data class TestRule(
+    var selector: String = "*",
+    var exclusive: Boolean = false,
+    var vmArguments: String = "",
+    var scriptParameters: String = "",
+    var environmentVariables: String = ""
+)

--- a/src/main/kotlin/com/github/sorinflorea/runconfigextras/rules/TestRuleMatcher.kt
+++ b/src/main/kotlin/com/github/sorinflorea/runconfigextras/rules/TestRuleMatcher.kt
@@ -1,0 +1,72 @@
+package com.github.sorinflorea.runconfigextras.rules
+
+object TestRuleMatcher {
+
+    private val EXACT_PATTERN = Regex("^:.+:.+$")        // :sub:task (any depth)
+    private val SUB_WILDCARD = Regex("^:.+:\\*$")         // :sub:*
+    private val TASK_WILDCARD = Regex("^\\*:.+$")         // *:task
+    private val CATCH_ALL = Regex("^\\*$")                // *
+
+    fun isValidSelector(selector: String): Boolean {
+        return EXACT_PATTERN.matches(selector)
+            || SUB_WILDCARD.matches(selector)
+            || TASK_WILDCARD.matches(selector)
+            || CATCH_ALL.matches(selector)
+    }
+
+    fun matches(selector: String, subproject: String, task: String): Boolean {
+        return when {
+            CATCH_ALL.matches(selector) -> true
+            TASK_WILDCARD.matches(selector) -> {
+                val selectorTask = selector.substringAfter("*:")
+                selectorTask == task
+            }
+            SUB_WILDCARD.matches(selector) -> {
+                val selectorSub = selector.substringBeforeLast(":*")
+                selectorSub == subproject
+            }
+            EXACT_PATTERN.matches(selector) -> {
+                val selectorSub = selector.substringBeforeLast(":")
+                val selectorTask = selector.substringAfterLast(":")
+                selectorSub == subproject && selectorTask == task
+            }
+            else -> false
+        }
+    }
+
+    data class MergedResult(
+        val vmArguments: String,
+        val scriptParameters: String,
+        val environmentVariables: String
+    )
+
+    private fun specificity(selector: String): Int = when {
+        EXACT_PATTERN.matches(selector) -> 3
+        SUB_WILDCARD.matches(selector) -> 2
+        TASK_WILDCARD.matches(selector) -> 1
+        CATCH_ALL.matches(selector) -> 0
+        else -> -1
+    }
+
+    fun findMatchingRules(rules: List<TestRule>, subproject: String, task: String): List<TestRule> {
+        return rules
+            .filter { matches(it.selector, subproject, task) }
+            .sortedByDescending { specificity(it.selector) }
+    }
+
+    fun mergeRules(sortedRules: List<TestRule>): MergedResult {
+        if (sortedRules.isEmpty()) return MergedResult("", "", "")
+
+        val effective = mutableListOf<TestRule>()
+        for (rule in sortedRules) {
+            effective.add(rule)
+            if (rule.exclusive) break
+        }
+
+        return MergedResult(
+            vmArguments = effective.mapNotNull { it.vmArguments.ifBlank { null } }.joinToString(" "),
+            scriptParameters = effective.mapNotNull { it.scriptParameters.ifBlank { null } }.joinToString(" "),
+            environmentVariables = effective.mapNotNull { it.environmentVariables.ifBlank { null } }.joinToString(" ")
+        )
+    }
+}

--- a/src/main/kotlin/com/github/sorinflorea/runconfigextras/rules/TestRulesConfigurable.kt
+++ b/src/main/kotlin/com/github/sorinflorea/runconfigextras/rules/TestRulesConfigurable.kt
@@ -1,0 +1,130 @@
+package com.github.sorinflorea.runconfigextras.rules
+
+import com.intellij.execution.configuration.EnvironmentVariablesTextFieldWithBrowseButton
+import com.intellij.openapi.options.BoundConfigurable
+import com.intellij.openapi.project.Project
+import com.intellij.ui.ToolbarDecorator
+import com.intellij.ui.dsl.builder.Align
+import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.table.TableView
+import com.intellij.util.ui.ColumnInfo
+import com.intellij.util.ui.ListTableModel
+import java.awt.Component
+import javax.swing.AbstractCellEditor
+import javax.swing.DefaultCellEditor
+import javax.swing.JTable
+import javax.swing.JTextField
+import javax.swing.table.TableCellEditor
+
+class TestRulesConfigurable(private val project: Project) : BoundConfigurable("Test Rules") {
+
+    private val rules = mutableListOf<TestRule>()
+
+    private val selectorColumn = object : ColumnInfo<TestRule, String>("Selector") {
+        override fun valueOf(item: TestRule) = item.selector
+        override fun setValue(item: TestRule, value: String) { item.selector = value }
+        override fun isCellEditable(item: TestRule) = true
+        override fun getEditor(item: TestRule): TableCellEditor = DefaultCellEditor(JTextField())
+        override fun getRenderer(item: TestRule) = object : com.intellij.ui.ColoredTableCellRenderer() {
+            override fun customizeCellRenderer(
+                table: JTable, value: Any?, selected: Boolean, hasFocus: Boolean, row: Int, column: Int
+            ) {
+                val text = value as? String ?: ""
+                append(text)
+                if (text.isNotEmpty() && !TestRuleMatcher.isValidSelector(text)) {
+                    foreground = com.intellij.ui.JBColor.RED
+                    toolTipText = "Invalid selector. Use :subproject:task, :subproject:*, *:task, or *"
+                }
+            }
+        }
+    }
+
+    private val vmArgsColumn = object : ColumnInfo<TestRule, String>("VM Arguments") {
+        override fun valueOf(item: TestRule) = item.vmArguments
+        override fun setValue(item: TestRule, value: String) { item.vmArguments = value }
+        override fun isCellEditable(item: TestRule) = true
+        override fun getEditor(item: TestRule): TableCellEditor = DefaultCellEditor(JTextField())
+    }
+
+    private val scriptParamsColumn = object : ColumnInfo<TestRule, String>("Script Parameters") {
+        override fun valueOf(item: TestRule) = item.scriptParameters
+        override fun setValue(item: TestRule, value: String) { item.scriptParameters = value }
+        override fun isCellEditable(item: TestRule) = true
+        override fun getEditor(item: TestRule): TableCellEditor = DefaultCellEditor(JTextField())
+    }
+
+    private val envVarsColumn = object : ColumnInfo<TestRule, String>("Env Variables") {
+        override fun valueOf(item: TestRule) = item.environmentVariables
+        override fun setValue(item: TestRule, value: String) { item.environmentVariables = value }
+        override fun isCellEditable(item: TestRule) = true
+        override fun getEditor(item: TestRule): TableCellEditor = EnvVarsCellEditor()
+    }
+
+    private val exclusiveColumn = object : ColumnInfo<TestRule, Boolean>("Exclusive") {
+        override fun valueOf(item: TestRule) = item.exclusive
+        override fun setValue(item: TestRule, value: Boolean) { item.exclusive = value }
+        override fun isCellEditable(item: TestRule) = true
+        override fun getColumnClass() = java.lang.Boolean::class.java
+        override fun getWidth(table: JTable?) = 70
+    }
+
+    private val tableModel = ListTableModel(
+        arrayOf(selectorColumn, vmArgsColumn, scriptParamsColumn, envVarsColumn, exclusiveColumn),
+        rules
+    )
+
+    private val table = TableView(tableModel)
+
+    override fun createPanel() = panel {
+        group("Test Rules") {
+            row {
+                val decorator = ToolbarDecorator.createDecorator(table)
+                    .setAddAction { tableModel.addRow(TestRule()); tableModel.fireTableDataChanged() }
+                    .setRemoveAction {
+                        val selected = table.selectedRow
+                        if (selected >= 0) {
+                            tableModel.removeRow(selected)
+                            tableModel.fireTableDataChanged()
+                        }
+                    }
+                cell(decorator.createPanel())
+                    .align(Align.FILL)
+            }.resizableRow()
+            row {
+                comment(
+                    "Selectors: :subproject:task, :subproject:*, *:task, or * (match all)<br>" +
+                    "All matching rules are merged (most specific first)<br>" +
+                    "An exclusive rule stops the merge — less specific rules are ignored"
+                )
+            }
+        }
+    }
+
+    override fun isModified(): Boolean {
+        val saved = TestRulesSettings.getInstance(project).state.rules
+        return rules != saved
+    }
+
+    override fun apply() {
+        TestRulesSettings.getInstance(project).state.rules = rules.map { it.copy() }.toMutableList()
+    }
+
+    override fun reset() {
+        rules.clear()
+        rules.addAll(TestRulesSettings.getInstance(project).state.rules.map { it.copy() })
+        tableModel.fireTableDataChanged()
+    }
+
+    private class EnvVarsCellEditor : AbstractCellEditor(), TableCellEditor {
+        private val component = EnvironmentVariablesTextFieldWithBrowseButton()
+
+        override fun getCellEditorValue(): Any = component.text
+
+        override fun getTableCellEditorComponent(
+            table: JTable, value: Any?, isSelected: Boolean, row: Int, column: Int
+        ): Component {
+            component.text = value as? String ?: ""
+            return component
+        }
+    }
+}

--- a/src/main/kotlin/com/github/sorinflorea/runconfigextras/rules/TestRulesListener.kt
+++ b/src/main/kotlin/com/github/sorinflorea/runconfigextras/rules/TestRulesListener.kt
@@ -1,0 +1,49 @@
+package com.github.sorinflorea.runconfigextras.rules
+
+import com.intellij.execution.RunManagerListener
+import com.intellij.execution.RunnerAndConfigurationSettings
+import com.intellij.openapi.externalSystem.service.execution.ExternalSystemRunConfiguration
+import com.intellij.openapi.project.Project
+
+class TestRulesListener(private val project: Project) : RunManagerListener {
+
+    override fun runConfigurationAdded(settings: RunnerAndConfigurationSettings) {
+        if (!settings.isTemporary) return
+
+        val config = settings.configuration
+        if (config !is ExternalSystemRunConfiguration) return
+
+        val taskPath = config.settings.taskNames.firstOrNull { it.startsWith(":") } ?: return
+        val lastColon = taskPath.lastIndexOf(':')
+        if (lastColon <= 0) return
+        val subproject = taskPath.substring(0, lastColon)
+        val task = taskPath.substring(lastColon + 1)
+
+        val rules = TestRulesSettings.getInstance(project).state.rules
+        val matching = TestRuleMatcher.findMatchingRules(rules, subproject, task)
+        if (matching.isEmpty()) return
+
+        val merged = TestRuleMatcher.mergeRules(matching)
+
+        if (merged.vmArguments.isNotBlank()) {
+            val existing = config.settings.vmOptions?.takeIf { it.isNotBlank() }
+            config.settings.vmOptions = listOfNotNull(existing, merged.vmArguments).joinToString(" ")
+        }
+
+        if (merged.scriptParameters.isNotBlank()) {
+            val existing = config.settings.scriptParameters?.takeIf { it.isNotBlank() }
+            config.settings.scriptParameters = listOfNotNull(existing, merged.scriptParameters).joinToString(" ")
+        }
+
+        if (merged.environmentVariables.isNotBlank()) {
+            val env = config.settings.env.toMutableMap()
+            merged.environmentVariables.split(" ").forEach { pair ->
+                val eqIndex = pair.indexOf('=')
+                if (eqIndex > 0) {
+                    env[pair.substring(0, eqIndex)] = pair.substring(eqIndex + 1)
+                }
+            }
+            config.settings.env = env
+        }
+    }
+}

--- a/src/main/kotlin/com/github/sorinflorea/runconfigextras/rules/TestRulesSettings.kt
+++ b/src/main/kotlin/com/github/sorinflorea/runconfigextras/rules/TestRulesSettings.kt
@@ -1,0 +1,30 @@
+package com.github.sorinflorea.runconfigextras.rules
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.project.Project
+
+@State(name = "RunConfigExtrasTestRules", storages = [Storage("runConfigExtrasTestRules.xml")])
+@Service(Service.Level.PROJECT)
+class TestRulesSettings : PersistentStateComponent<TestRulesSettings.State> {
+
+    class State {
+        var rules: MutableList<TestRule> = mutableListOf()
+    }
+
+    private var state = State()
+
+    override fun getState(): State = state
+
+    override fun loadState(state: State) {
+        this.state = state
+    }
+
+    companion object {
+        fun getInstance(project: Project): TestRulesSettings {
+            return project.getService(TestRulesSettings::class.java)
+        }
+    }
+}

--- a/src/main/kotlin/com/github/sorinflorea/runconfigextras/settings/PluginConfigurable.kt
+++ b/src/main/kotlin/com/github/sorinflorea/runconfigextras/settings/PluginConfigurable.kt
@@ -1,0 +1,17 @@
+package com.github.sorinflorea.runconfigextras.settings
+
+import com.intellij.openapi.options.BoundConfigurable
+import com.intellij.ui.dsl.builder.bindSelected
+import com.intellij.ui.dsl.builder.panel
+
+class PluginConfigurable : BoundConfigurable("Run Configuration Extras") {
+
+    override fun createPanel() = panel {
+        group("Gradle Task Name in Configuration Name") {
+            row {
+                checkBox("Replace configuration for the same test when run with a different task")
+                    .bindSelected(PluginSettings.instance.state::replaceExistingConfig)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/github/sorinflorea/runconfigextras/settings/PluginSettings.kt
+++ b/src/main/kotlin/com/github/sorinflorea/runconfigextras/settings/PluginSettings.kt
@@ -1,0 +1,29 @@
+package com.github.sorinflorea.runconfigextras.settings
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+
+@State(name = "RunConfigExtrasSettings", storages = [Storage("RunConfigExtras.xml")])
+@Service(Service.Level.APP)
+class PluginSettings : PersistentStateComponent<PluginSettings.State> {
+
+    class State {
+        var replaceExistingConfig: Boolean = false
+    }
+
+    private var state = State()
+
+    override fun getState(): State = state
+
+    override fun loadState(state: State) {
+        this.state = state
+    }
+
+    companion object {
+        val instance: PluginSettings
+            get() = ApplicationManager.getApplication().getService(PluginSettings::class.java)
+    }
+}

--- a/src/main/resources/META-INF/gradle-support.xml
+++ b/src/main/resources/META-INF/gradle-support.xml
@@ -1,3 +1,10 @@
 <idea-plugin>
-    <!-- Extensions activated when the Gradle plugin is present -->
+    <extensions defaultExtensionNs="com.intellij">
+        <projectService
+                serviceImplementation="com.github.sorinflorea.runconfigextras.rules.TestRulesSettings"/>
+    </extensions>
+    <projectListeners>
+        <listener class="com.github.sorinflorea.runconfigextras.rules.TestRulesListener"
+                  topic="com.intellij.execution.RunManagerListener"/>
+    </projectListeners>
 </idea-plugin>

--- a/src/main/resources/META-INF/gradle-support.xml
+++ b/src/main/resources/META-INF/gradle-support.xml
@@ -1,0 +1,3 @@
+<idea-plugin>
+    <!-- Extensions activated when the Gradle plugin is present -->
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -43,5 +43,10 @@
                 instance="com.github.sorinflorea.runconfigextras.settings.PluginConfigurable"
                 id="RunConfigExtras.Settings"
                 displayName="Run Configuration Extras"/>
+        <projectConfigurable
+                parentId="RunConfigExtras.Settings"
+                instance="com.github.sorinflorea.runconfigextras.rules.TestRulesConfigurable"
+                id="RunConfigExtras.TestRules"
+                displayName="Test Rules"/>
     </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,6 +5,8 @@
 
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.java</depends>
+    <depends optional="true" config-file="gradle-support.xml">com.intellij.gradle</depends>
+
     <actions>
         <action id="RunConfigExtras.RunNewConfigurationAction"
                 class="com.github.sorinflorea.runconfigextras.actions.RunNewConfigAction"
@@ -34,5 +36,12 @@
                                   id="RunConfigExtras.RunNewConfigurationActionContributor"
                                   order="last"
                                   implementationClass="com.github.sorinflorea.runconfigextras.actions.RunNewConfigMarkerContributor"/>
+        <applicationService
+                serviceImplementation="com.github.sorinflorea.runconfigextras.settings.PluginSettings"/>
+        <applicationConfigurable
+                parentId="tools"
+                instance="com.github.sorinflorea.runconfigextras.settings.PluginConfigurable"
+                id="RunConfigExtras.Settings"
+                displayName="Run Configuration Extras"/>
     </extensions>
 </idea-plugin>

--- a/src/test/kotlin/com/github/sorinflorea/runconfigextras/rules/TestRuleMatcherTest.kt
+++ b/src/test/kotlin/com/github/sorinflorea/runconfigextras/rules/TestRuleMatcherTest.kt
@@ -1,0 +1,172 @@
+package com.github.sorinflorea.runconfigextras.rules
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class TestRuleMatcherTest {
+
+    // --- Step Group A: Selector validation ---
+
+    @Test
+    fun `valid selector - exact match`() {
+        assertTrue(TestRuleMatcher.isValidSelector(":core:test"))
+    }
+
+    @Test
+    fun `valid selector - subproject wildcard`() {
+        assertTrue(TestRuleMatcher.isValidSelector(":core:*"))
+    }
+
+    @Test
+    fun `valid selector - task wildcard`() {
+        assertTrue(TestRuleMatcher.isValidSelector("*:test"))
+    }
+
+    @Test
+    fun `valid selector - catch all`() {
+        assertTrue(TestRuleMatcher.isValidSelector("*"))
+    }
+
+    @Test
+    fun `invalid selector - empty string`() {
+        assertFalse(TestRuleMatcher.isValidSelector(""))
+    }
+
+    @Test
+    fun `invalid selector - no colon no star`() {
+        assertFalse(TestRuleMatcher.isValidSelector("foo"))
+    }
+
+    @Test
+    fun `invalid selector - missing task part`() {
+        assertFalse(TestRuleMatcher.isValidSelector(":core:"))
+    }
+
+    @Test
+    fun `valid selector - deeply nested exact match`() {
+        assertTrue(TestRuleMatcher.isValidSelector(":app:core:impl:test"))
+    }
+
+    @Test
+    fun `valid selector - deeply nested subproject wildcard`() {
+        assertTrue(TestRuleMatcher.isValidSelector(":app:core:impl:*"))
+    }
+
+    // --- Step Group B: Matching ---
+
+    @Test
+    fun `exact selector matches exact task path`() {
+        assertTrue(TestRuleMatcher.matches(":core:test", subproject = ":core", task = "test"))
+    }
+
+    @Test
+    fun `exact selector does not match different task`() {
+        assertFalse(TestRuleMatcher.matches(":core:test", subproject = ":core", task = "integrationTest"))
+    }
+
+    @Test
+    fun `subproject wildcard matches any task in subproject`() {
+        assertTrue(TestRuleMatcher.matches(":core:*", subproject = ":core", task = "integrationTest"))
+    }
+
+    @Test
+    fun `subproject wildcard does not match different subproject`() {
+        assertFalse(TestRuleMatcher.matches(":core:*", subproject = ":api", task = "test"))
+    }
+
+    @Test
+    fun `task wildcard matches task in any subproject`() {
+        assertTrue(TestRuleMatcher.matches("*:test", subproject = ":api", task = "test"))
+    }
+
+    @Test
+    fun `task wildcard does not match different task`() {
+        assertFalse(TestRuleMatcher.matches("*:test", subproject = ":api", task = "integrationTest"))
+    }
+
+    @Test
+    fun `catch all matches anything`() {
+        assertTrue(TestRuleMatcher.matches("*", subproject = ":anything", task = "whatever"))
+    }
+
+    @Test
+    fun `exact selector matches deeply nested task path`() {
+        assertTrue(TestRuleMatcher.matches(":app:core:impl:test", subproject = ":app:core:impl", task = "test"))
+    }
+
+    @Test
+    fun `subproject wildcard matches deeply nested subproject`() {
+        assertTrue(TestRuleMatcher.matches(":app:core:impl:*", subproject = ":app:core:impl", task = "integrationTest"))
+    }
+
+    @Test
+    fun `task wildcard matches deeply nested subproject`() {
+        assertTrue(TestRuleMatcher.matches("*:test", subproject = ":app:core:impl", task = "test"))
+    }
+
+    // --- Step Group C: Specificity and merging ---
+
+    @Test
+    fun `specificity ordering - exact is most specific`() {
+        val rules = listOf(
+            TestRule(selector = "*", vmArguments = "-Da=1"),
+            TestRule(selector = ":core:test", vmArguments = "-Dc=3"),
+            TestRule(selector = "*:test", vmArguments = "-Db=2"),
+        )
+        val sorted = TestRuleMatcher.findMatchingRules(rules, subproject = ":core", task = "test")
+        assertEquals(listOf("-Dc=3", "-Db=2", "-Da=1"), sorted.map { it.vmArguments })
+    }
+
+    @Test
+    fun `merge concatenates all fields`() {
+        val rules = listOf(
+            TestRule(selector = ":core:*", vmArguments = "-Da=1", scriptParameters = "--info"),
+            TestRule(selector = "*:test", environmentVariables = "DB=local"),
+        )
+        val merged = TestRuleMatcher.mergeRules(
+            TestRuleMatcher.findMatchingRules(rules, subproject = ":core", task = "test")
+        )
+        assertEquals("-Da=1", merged.vmArguments)
+        assertEquals("--info", merged.scriptParameters)
+        assertEquals("DB=local", merged.environmentVariables)
+    }
+
+    @Test
+    fun `exclusive rule drops less specific rules`() {
+        val rules = listOf(
+            TestRule(selector = ":core:test", vmArguments = "-Da=1", exclusive = true),
+            TestRule(selector = "*:test", vmArguments = "-Db=2"),
+            TestRule(selector = "*", vmArguments = "-Dc=3"),
+        )
+        val merged = TestRuleMatcher.mergeRules(
+            TestRuleMatcher.findMatchingRules(rules, subproject = ":core", task = "test")
+        )
+        assertEquals("-Da=1", merged.vmArguments)
+    }
+
+    @Test
+    fun `exclusive at mid specificity keeps higher specificity`() {
+        val rules = listOf(
+            TestRule(selector = ":core:test", vmArguments = "-Da=1"),
+            TestRule(selector = "*:test", vmArguments = "-Db=2", exclusive = true),
+            TestRule(selector = "*", vmArguments = "-Dc=3"),
+        )
+        val merged = TestRuleMatcher.mergeRules(
+            TestRuleMatcher.findMatchingRules(rules, subproject = ":core", task = "test")
+        )
+        assertEquals("-Da=1 -Db=2", merged.vmArguments)
+    }
+
+    @Test
+    fun `no matching rules returns empty merge result`() {
+        val rules = listOf(
+            TestRule(selector = ":api:test", vmArguments = "-Da=1"),
+        )
+        val merged = TestRuleMatcher.mergeRules(
+            TestRuleMatcher.findMatchingRules(rules, subproject = ":core", task = "test")
+        )
+        assertEquals("", merged.vmArguments)
+        assertEquals("", merged.scriptParameters)
+        assertEquals("", merged.environmentVariables)
+    }
+}

--- a/src/test/kotlin/com/github/sorinflorea/runconfigextras/rules/TestRulesListenerTest.kt
+++ b/src/test/kotlin/com/github/sorinflorea/runconfigextras/rules/TestRulesListenerTest.kt
@@ -1,0 +1,146 @@
+package com.github.sorinflorea.runconfigextras.rules
+
+import com.intellij.execution.RunManagerEx
+import com.intellij.openapi.externalSystem.service.execution.ExternalSystemRunConfiguration
+import com.intellij.openapi.project.Project
+import com.intellij.testFramework.junit5.TestApplication
+import com.intellij.testFramework.junit5.fixture.projectFixture
+import org.jetbrains.plugins.gradle.service.execution.GradleExternalTaskConfigurationType
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@TestApplication
+class TestRulesListenerTest {
+
+    companion object {
+        private val projectFixture = projectFixture()
+    }
+
+    private val project: Project get() = projectFixture.get()
+    private lateinit var runManager: RunManagerEx
+
+    @BeforeEach
+    fun setUp() {
+        runManager = RunManagerEx.getInstanceEx(project)
+        TestRulesSettings.getInstance(project).state.rules.clear()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        runManager.allSettings.forEach { runManager.removeConfiguration(it) }
+        TestRulesSettings.getInstance(project).state.rules.clear()
+    }
+
+    private fun createGradleConfig(name: String, taskPath: String): com.intellij.execution.RunnerAndConfigurationSettings {
+        val configType = GradleExternalTaskConfigurationType.getInstance()
+        val factory = configType.configurationFactories[0]
+        val settings = runManager.createConfiguration(name, factory)
+        val config = settings.configuration as ExternalSystemRunConfiguration
+        config.settings.taskNames = listOf(taskPath)
+        return settings
+    }
+
+    @Test
+    fun `applies vm arguments to matching temporary config`() {
+        TestRulesSettings.getInstance(project).state.rules.add(
+            TestRule(selector = "*:test", vmArguments = "-Dfoo=bar")
+        )
+
+        val settings = createGradleConfig("MyTest", ":core:test")
+        settings.isTemporary = true
+        runManager.addConfiguration(settings)
+
+        val config = settings.configuration as ExternalSystemRunConfiguration
+        assertTrue(config.settings.vmOptions?.contains("-Dfoo=bar") == true)
+    }
+
+    @Test
+    fun `applies script parameters to matching temporary config`() {
+        TestRulesSettings.getInstance(project).state.rules.add(
+            TestRule(selector = ":core:*", scriptParameters = "--info")
+        )
+
+        val settings = createGradleConfig("MyTest", ":core:test")
+        settings.isTemporary = true
+        runManager.addConfiguration(settings)
+
+        val config = settings.configuration as ExternalSystemRunConfiguration
+        assertTrue(config.settings.scriptParameters?.contains("--info") == true)
+    }
+
+    @Test
+    fun `applies environment variables to matching temporary config`() {
+        TestRulesSettings.getInstance(project).state.rules.add(
+            TestRule(selector = "*", environmentVariables = "DB_HOST=localhost")
+        )
+
+        val settings = createGradleConfig("MyTest", ":core:test")
+        settings.isTemporary = true
+        runManager.addConfiguration(settings)
+
+        val config = settings.configuration as ExternalSystemRunConfiguration
+        assertEquals("localhost", config.settings.env["DB_HOST"])
+    }
+
+    @Test
+    fun `skips non-temporary configs`() {
+        TestRulesSettings.getInstance(project).state.rules.add(
+            TestRule(selector = "*", vmArguments = "-Dfoo=bar")
+        )
+
+        val settings = createGradleConfig("MyTest", ":core:test")
+        settings.isTemporary = false
+        runManager.addConfiguration(settings)
+
+        val config = settings.configuration as ExternalSystemRunConfiguration
+        assertNull(config.settings.vmOptions)
+    }
+
+    @Test
+    fun `appends to existing vm options`() {
+        TestRulesSettings.getInstance(project).state.rules.add(
+            TestRule(selector = "*", vmArguments = "-Dfoo=bar")
+        )
+
+        val settings = createGradleConfig("MyTest", ":core:test")
+        val config = settings.configuration as ExternalSystemRunConfiguration
+        config.settings.vmOptions = "-Xmx512m"
+        settings.isTemporary = true
+        runManager.addConfiguration(settings)
+
+        assertTrue(config.settings.vmOptions?.contains("-Xmx512m") == true)
+        assertTrue(config.settings.vmOptions?.contains("-Dfoo=bar") == true)
+    }
+
+    @Test
+    fun `merges multiple matching rules`() {
+        val rules = TestRulesSettings.getInstance(project).state.rules
+        rules.add(TestRule(selector = ":core:*", vmArguments = "-Da=1"))
+        rules.add(TestRule(selector = "*:test", vmArguments = "-Db=2"))
+
+        val settings = createGradleConfig("MyTest", ":core:test")
+        settings.isTemporary = true
+        runManager.addConfiguration(settings)
+
+        val config = settings.configuration as ExternalSystemRunConfiguration
+        val vmOpts = config.settings.vmOptions ?: ""
+        assertTrue(vmOpts.contains("-Da=1"))
+        assertTrue(vmOpts.contains("-Db=2"))
+    }
+
+    @Test
+    fun `no matching rules leaves config unchanged`() {
+        TestRulesSettings.getInstance(project).state.rules.add(
+            TestRule(selector = ":api:test", vmArguments = "-Dfoo=bar")
+        )
+
+        val settings = createGradleConfig("MyTest", ":core:test")
+        settings.isTemporary = true
+        runManager.addConfiguration(settings)
+
+        val config = settings.configuration as ExternalSystemRunConfiguration
+        assertNull(config.settings.vmOptions)
+    }
+}


### PR DESCRIPTION
### Summary
- Add per-project test rules that automatically inject VM arguments, script parameters, and environment variables into Gradle test configurations when created from context (gutter, context menu, keyboard shortcut)
- Settings UI under Tools > Run Configuration Extras > Test Rules
- JUnit 5 test framework for plugin tests

Note: this one is based on PR #2 

### Test Rules

Rules match configurations by selector pattern against the Gradle task path:

| Selector | Matches |
|---|---|
| `:subproject:task` | Exact match (supports nesting: `:app:core:test`) |
| `:subproject:*` | Any task in that subproject |
| `*:task` | That task in any subproject |
| `*` | Everything |

All matching rules merge by default (most specific first). A rule marked **exclusive** stops the merge — less specific rules are ignored. Only temporary (context-triggered) configs are modified; saved configs are never touched.

### How it works

A `RunManagerListener` fires on `runConfigurationAdded`. For each new temporary `ExternalSystemRunConfiguration`, it parses the task path into subproject + task, finds matching rules sorted by specificity, merges them (respecting exclusive flags), and appends VM arguments, script parameters, and environment variables to the config.

Rules are stored per-project via `PersistentStateComponent` in `.idea/runConfigExtrasTestRules.xml`.

<img width="1052" height="671" alt="image" src="https://github.com/user-attachments/assets/534048e6-4143-4198-b8af-f5ba47e89b89" />